### PR TITLE
Add index.js to the files list

### DIFF
--- a/packages/ember-mirage/package.json
+++ b/packages/ember-mirage/package.json
@@ -10,7 +10,8 @@
   "author": "Brian Gantzler",
   "files": [
     "addon",
-    "addon-test-support"
+    "addon-test-support",
+    "index.js"
   ],
   "scripts": {
     "lint": "pnpm -w exec turbo _:lint --filter ember-mirage",


### PR DESCRIPTION
Noticed in the automation that what we can point our package.json's at: https://github.com/bgantzler/ember-mirage/tree/ember-mirage-dist
we were missing the index.js! (a required file in v1 addons)