### PR TITLE
reset addon version to what is deployed on npm

### DIFF
--- a/ember-mirage/package.json
+++ b/ember-mirage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-mirage",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "The default blueprint for Embroider v2 addons.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
I noticed this because #29 is trying to release a 0.1.0 version (which is lower than the version currently on npm 🙃)

I originally thought this was reset in my #26 PR but it looks like it changed earlier in https://github.com/bgantzler/ember-mirage/pull/14 👍 