### PR TITLE
fix github backlink from npm

### DIFF
--- a/test-app/package.json
+++ b/test-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Test app for ember-mirage addon",
-  "repository": "",
+  "repository": "https://github.com/bgantzler/ember-mirage",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
it turns out that we need to make sure that both the root and the actual addon package.json has correct repository links, this adds the one to the main addon package.json