### PR TITLE
Widen peer range for miragejs

### DIFF
--- a/ember-mirage/package.json
+++ b/ember-mirage/package.json
@@ -38,7 +38,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "miragejs": "^0.1.47"
+    "miragejs": ">= 0.1.47"
   },
   "devDependencies": {
     "@babel/core": "^7.23.6",


### PR DESCRIPTION
When using npm,
```bash
❯ npm i
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: board@0.0.0
npm error Found: miragejs@0.2.0-alpha.3
npm error node_modules/miragejs
npm error   dev miragejs@"0.2.0-alpha.3" from the root project
npm error
npm error Could not resolve dependency:
npm error peer miragejs@"^0.1.47" from ember-mirage@0.3.1
npm error node_modules/ember-mirage
npm error   dev ember-mirage@"github:bgantzler/ember-mirage#1ac0cfc" from the root project
npm error
npm error Fix t
```