### PR TITLE
move qunit config out of module scope

### DIFF
--- a/ember-mirage/src/test-support.js
+++ b/ember-mirage/src/test-support.js
@@ -1,10 +1,1 @@
-import { dependencySatisfies } from '@embroider/macros';
-
-if (dependencySatisfies('ember-qunit', '*')) {
-  window.QUnit.config.urlConfig.push({
-    id: 'mirageLogging',
-    label: 'Mirage logging',
-  });
-}
-
 export { setupMirage } from './test-support/setup-mirage';

--- a/ember-mirage/src/test-support/setup-mirage.js
+++ b/ember-mirage/src/test-support/setup-mirage.js
@@ -1,6 +1,9 @@
 import { assert } from '@ember/debug';
 import { settled } from '@ember/test-helpers';
 import { createServer as _createServer } from 'miragejs';
+import { dependencySatisfies } from '@embroider/macros';
+
+let qunitSetUp = false;
 
 export function setupMirage(hooks = self, { createServer, config }) {
   assert(
@@ -46,4 +49,13 @@ export function setupMirage(hooks = self, { createServer, config }) {
       }
     });
   });
+
+  // the qunitSetUp guard is to prevent this from pushing multiple copies of the same config option
+  if (dependencySatisfies('ember-qunit', '*') && !qunitSetUp) {
+    window.QUnit.config.urlConfig.push({
+      id: 'mirageLogging',
+      label: 'Mirage logging',
+    });
+    qunitSetUp = true;
+  }
 }


### PR DESCRIPTION
We need to delay the point that we're accessing `window.QUnit` because in Vite we have delayed actually starting until after all the modules are loaded. Having this code run in a function means that we can guarantee when it happens without having to be careful about what order we import things 👍 